### PR TITLE
chore: add check for outdated unocha packages

### DIFF
--- a/composer-update/action.yml
+++ b/composer-update/action.yml
@@ -88,6 +88,13 @@ runs:
       run: composer outdated
     continue-on-error: false
 
+  - name: Composer Outdated Unocha packages
+    id: outdated
+    uses: cafuego/command-output@main
+    with:
+      run: composer outdated unocha/*
+    continue-on-error: false
+
   - name: Composer Update
     id: update
     uses: cafuego/command-output@main


### PR DESCRIPTION
Refs: OPS-8658

Not sure we want to automatically update `unocha/*` packages quite yet, while there's still work on the new version of the common design, but it would be good to know at least if packages are out of date.

I imagine there's a better way to do this (I was tempted to put `{{ inputs.uncha-vendor-name }}`, but that feels redundant).