### PR TITLE
Specify composer version for updates

### DIFF
--- a/composer-update/action.yml
+++ b/composer-update/action.yml
@@ -53,7 +53,7 @@ runs:
     with:
       php-version: ${{ inputs.php_version }}
       extensions: gd, mbstring, xmlwriter, dom, curl
-      tools: composer
+      tools: composer:2.5.5
     env:
       fail-fast: true
 


### PR DESCRIPTION
Until drupal-composer/preserve-patches is updated to cope with the changes in composer:^2.5.6 - the format of the pinning should be checked.