### PR TITLE
chore: unpin composer version

### DIFF
--- a/composer-update/action.yml
+++ b/composer-update/action.yml
@@ -67,7 +67,7 @@ runs:
     with:
       php-version: ${{ steps.php.outputs.php_version }}
       extensions: gd, mbstring, xmlwriter, dom, curl
-      tools: composer:2.5.5
+      tools: composer
     env:
       fail-fast: true
 


### PR DESCRIPTION
Refs: OPS-9635

There's an (unmerged) PR to remove preserve-paths from HRinfo, https://github.com/UN-OCHA/hrinfo-site/pull/1292, which is the last remaining reason to pin composer at 2.5.5.