### PR TITLE
chore: run outdated check after the updates

### DIFF
--- a/composer-update/action.yml
+++ b/composer-update/action.yml
@@ -118,18 +118,18 @@ runs:
       run: composer install --no-scripts
     continue-on-error: true
 
-  - name: Composer Outdated
-    id: outdated
-    uses: cafuego/command-output@main
-    with:
-      run: composer outdated --direct --no-scripts
-    continue-on-error: false
-
   - name: Composer Update
     id: update
     uses: cafuego/command-output@main
     with:
       run: composer update --with-all-dependencies ${{ inputs.patch_packages }} --no-scripts
+    continue-on-error: false
+
+  - name: Composer Outdated
+    id: outdated
+    uses: cafuego/command-output@main
+    with:
+      run: composer outdated --direct --no-scripts
     continue-on-error: false
 
   - name: Build Image


### PR DESCRIPTION
Refs: OPS-11022

Wondering if the output of `outdated` would be more useful if without including the packages already updated (and listed as so in the output above.)