### PR TITLE
updates: allow composer update with drupal-lenient

### DIFF
--- a/composer-update/action.yml
+++ b/composer-update/action.yml
@@ -15,6 +15,11 @@ inputs:
     required: false
     type: string
     default: "us-east-1"
+  composer_scripts:
+    description: "A flag that specifies whether to run composer scripts"
+    required: false
+    type: string
+    default: "false"
   github_access_token:
     description: "A GitHub personal access token."
     required: true
@@ -121,18 +126,36 @@ runs:
     env:
       AWS_REGION: us-east-1
 
-  - name: Composer Install
+  - name: Composer Install without scripts
     id: install
+    if: inputs.composer_scripts == 'false'
     uses: cafuego/command-output@main
     with:
       run: composer install --no-interaction --prefer-dist --no-scripts
     continue-on-error: true
 
-  - name: Composer Update
+  - name: Composer Install with scripts
+    id: install
+    if: inputs.composer_scripts == 'true'
+    uses: cafuego/command-output@main
+    with:
+      run: composer install --no-interaction --prefer-dist
+    continue-on-error: true
+
+  - name: Composer Update without scripts
     id: update
+    if: inputs.composer_scripts == 'false'
     uses: cafuego/command-output@main
     with:
       run: composer update --with-all-dependencies ${{ inputs.patch_packages }} --no-interaction --prefer-dist --no-scripts
+    continue-on-error: false
+
+  - name: Composer Update with scripts
+    id: update
+    if: inputs.composer_scripts == 'true'
+    uses: cafuego/command-output@main
+    with:
+      run: composer update --with-all-dependencies ${{ inputs.patch_packages }} --no-interaction --prefer-dist
     continue-on-error: false
 
   - name: Composer Outdated

--- a/composer-update/action.yml
+++ b/composer-update/action.yml
@@ -127,7 +127,7 @@ runs:
       AWS_REGION: us-east-1
 
   - name: Composer Install without scripts
-    id: install
+    id: install-no-scripts
     if: inputs.composer_scripts == 'false'
     uses: cafuego/command-output@main
     with:
@@ -135,7 +135,7 @@ runs:
     continue-on-error: true
 
   - name: Composer Install with scripts
-    id: install
+    id: install-scripts
     if: inputs.composer_scripts == 'true'
     uses: cafuego/command-output@main
     with:
@@ -143,7 +143,7 @@ runs:
     continue-on-error: true
 
   - name: Composer Update without scripts
-    id: update
+    id: update-no-scripts
     if: inputs.composer_scripts == 'false'
     uses: cafuego/command-output@main
     with:
@@ -151,7 +151,7 @@ runs:
     continue-on-error: false
 
   - name: Composer Update with scripts
-    id: update
+    id: update-scripts
     if: inputs.composer_scripts == 'true'
     uses: cafuego/command-output@main
     with:


### PR DESCRIPTION
Refs: OPS-11381

Tested with Starterkit and ODSG - I think we could just test for Drupal sites instead of adding a flag, but this gives more control.

The 'clumsy' in the commit message is because I thought I'd be able to put a conditional around just the command itself, not the whole step.